### PR TITLE
Fetch images from backplane pipeline

### DIFF
--- a/hack/scripts/dev-update-image-references.py
+++ b/hack/scripts/dev-update-image-references.py
@@ -6,11 +6,13 @@ import glob
 import json
 import yaml
 import argparse
+import shutil
 
 def getLatestManifest():
     pipelineDir = os.path.join(os.getcwd(), "bin/pipeline")
-    if not os.path.exists(pipelineDir):
-        Repo.clone_from("https://github.com/open-cluster-management/pipeline.git", pipelineDir)
+    if os.path.exists(pipelineDir):
+        shutil.rmtree(pipelineDir)
+    Repo.clone_from("https://github.com/open-cluster-management/backplane-pipeline.git", pipelineDir)
     manifests = glob.glob('bin/pipeline/snapshots/manifest-*.json')
     manifests.sort()
     return manifests[-1]


### PR DESCRIPTION
Reclone pipeline on each run. Gather from backplane-pipeline repo (rather than pipeline repo).

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>