### PR TITLE
Report status while mce uninstalls

### DIFF
--- a/api/v1alpha1/multiclusterengine_types.go
+++ b/api/v1alpha1/multiclusterengine_types.go
@@ -84,9 +84,10 @@ type ComponentCondition struct {
 type PhaseType string
 
 const (
-	MultiClusterEnginePhaseProgressing PhaseType = "Progressing"
-	MultiClusterEnginePhaseAvailable   PhaseType = "Available"
-	MultiClusterEnginePhaseError       PhaseType = "Error"
+	MultiClusterEnginePhaseProgressing  PhaseType = "Progressing"
+	MultiClusterEnginePhaseAvailable    PhaseType = "Available"
+	MultiClusterEnginePhaseUninstalling PhaseType = "Uninstalling"
+	MultiClusterEnginePhaseError        PhaseType = "Error"
 )
 
 type MultiClusterEngineConditionType string

--- a/pkg/status/condition.go
+++ b/pkg/status/condition.go
@@ -18,6 +18,10 @@ const (
 	// RequirementsNotMetReason is when there is something missing or misconfigured
 	// that is preventing progress
 	RequirementsNotMetReason = "RequirementsNotMet"
+	// DeleteTimestampReason means the resource is schedule for deletion with a DeletionTimestamp present
+	DeleteTimestampReason = "DeletionTimestampPresent"
+	// WaitingForResourceReason means the reconciler is waiting on a resource before it can progress
+	WaitingForResourceReason = "WaitingForResource"
 )
 
 // NewCondition creates a new condition.


### PR DESCRIPTION
Display uninstall status in phase when mce is deleted. Report an error
if mce is stuck waiting for clustermanager to clean up after five minutes.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>