### PR TITLE
ZK Exerimentation

### DIFF
--- a/hack/import-cluster/hub-cluster/Chart.yaml
+++ b/hack/import-cluster/hub-cluster/Chart.yaml
@@ -1,0 +1,3 @@
+description: Test MCE Deploy app
+name: dev-cluster
+version: 1.0.0

--- a/hack/import-cluster/hub-cluster/templates/managed_cluster_cr.yaml
+++ b/hack/import-cluster/hub-cluster/templates/managed_cluster_cr.yaml
@@ -1,0 +1,25 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  labels:
+    {{- range $key, $value := .Values.managedCluster.labels }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+    {{- if eq .Values.managedCluster.name "local-cluster" }}
+    local-cluster: "true"
+    {{- end }}
+    {{- if .Values.managedCluster.cloud }}
+    cloud: {{ .Values.managedCluster.cloud }}
+    {{- end}}
+    {{- if .Values.managedCluster.vendor }}
+    vendor: {{ .Values.managedCluster.vendor }}
+    {{- end}}
+    {{- if .Values.managedCluster.name }}
+    name: "{{ .Values.managedCluster.name }}"
+    {{- end}}
+  name: "{{ .Values.managedCluster.name }}"
+spec:
+  hubAcceptsClient: true
+  leaseDurationSeconds: 60

--- a/hack/import-cluster/hub-cluster/templates/managed_cluster_secret.yaml
+++ b/hack/import-cluster/hub-cluster/templates/managed_cluster_secret.yaml
@@ -1,0 +1,21 @@
+# Copyright Contributors to the Open Cluster Management project
+
+{{- $needed := (printf "%s%s" .Values.managedCluster.kubeConfig .Values.managedCluster.token) }}
+{{- if not (eq $needed "" "%!s(<nil>)" "%!s(<nil>)%!s(<nil>)" ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: auto-import-secret
+  namespace: "{{ .Values.managedCluster.name }}"
+stringData:
+  autoImportRetry: "{{ .Values.managedCluster.autoImportRetry }}"
+{{- if .Values.managedCluster.kubeConfig }}
+  kubeconfig: |- 
+{{ .Values.managedCluster.kubeConfig | indent 4 }}
+{{- end }}
+{{- if .Values.managedCluster.token }}
+  token: {{ .Values.managedCluster.token }}
+  server: {{ .Values.managedCluster.server }}
+{{- end }}
+type: Opaque
+{{- end }}

--- a/hack/import-cluster/hub-cluster/templates/namespace.yaml
+++ b/hack/import-cluster/hub-cluster/templates/namespace.yaml
@@ -1,0 +1,6 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "{{ .Values.managedCluster.name }}"

--- a/hack/import-cluster/hub-cluster/values.yaml
+++ b/hack/import-cluster/hub-cluster/values.yaml
@@ -1,0 +1,18 @@
+# Copyright Contributors to the Open Cluster Management project
+
+managedCluster:
+  name: dev-cluster 
+  labels: # map of custom labels, if cloud and vendor labels are not specified they will be set to "auto-detect"
+    environment: Dev # Set up labels here to match with placement policies
+  autoImportRetry: 5
+  # For automatically import the cluster, 
+  # provide the kubeconfig or the server/token pair
+  # The cluster kubeconfig, token and server can also be passed as parameter
+  # The parameters override these values
+  # Provide either KubeConfig, or Token and API Server URL. As of now does not support manual import.
+  kubeConfig: |-
+    
+  token: ""
+  server: ""
+    
+

--- a/hack/import-cluster/start.sh
+++ b/hack/import-cluster/start.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+# 1. Validate values.yaml (Needs kubeconfig or token and server)
+# 2. Copy values.yaml over to hub-cluster and spoke-cluster folders
+# 3. Apply hub-cluster manifests
+# 4. Sign into spoke cluster and apply spoke-cluster manifests
+
+_BASEDIR=$(dirname "$0")
+
+_SPOKE_TOKEN=$(yq eval '.managedCluster.token' $_BASEDIR/values.yaml)
+_SPOKE_SERVER=$(yq eval '.managedCluster.server' $_BASEDIR/values.yaml)
+_SPOKE_KUBECONFIG=$(yq eval '.managedCluster.kubeConfig' $_BASEDIR/values.yaml)
+
+
+if [[ -z "$_SPOKE_TOKEN" || -z "$_SPOKE_SERVER" ]]; then
+    echo "INFO: Missing token or server in values.yaml. Checking for kubeconfig"
+    if [[ -z "$_SPOKE_KUBECONFIG" ]]; then
+        echo "Error: No auth methods provided. Failing. A token and server or kubeconfig must be provided"
+        exit 1
+    fi
+fi
+
+cp $_BASEDIR/values.yaml $_BASEDIR/hub-cluster/values.yaml
+
+resources=$(helm template hub $_BASEDIR/hub-cluster)
+
+for filename in $_BASEDIR/hub-cluster/templates/*.yaml; do
+    filename=$(basename $filename)
+    output=$(helm template hub $_BASEDIR/hub-cluster -s templates/$filename)
+    echo "$output" | kubectl apply -f -
+done

--- a/hack/import-cluster/uninstall.sh
+++ b/hack/import-cluster/uninstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+_BASEDIR=$(dirname "$0")
+
+oc delete managedcluster $(yq eval '.managedCluster.name' $_BASEDIR/values.yaml)

--- a/hack/import-cluster/values.yaml
+++ b/hack/import-cluster/values.yaml
@@ -1,0 +1,18 @@
+# Copyright Contributors to the Open Cluster Management project
+
+managedCluster:
+  name: dev-cluster 
+  labels: # map of custom labels, if cloud and vendor labels are not specified they will be set to "auto-detect"
+    environment: Dev # Set up labels here to match with placement policies
+  autoImportRetry: 5
+  # For automatically import the cluster, 
+  # provide the kubeconfig or the server/token pair
+  # The cluster kubeconfig, token and server can also be passed as parameter
+  # The parameters override these values
+  # Provide either KubeConfig, or Token and API Server URL. As of now does not support manual import.
+  kubeConfig: |-
+    
+  token: "" # Token for the cluster
+  server: "" ## API Server URL
+    
+


### PR DESCRIPTION
imports cluster

Signed-off-by: Zachary Kayyali <zkayyali@redhat.com>

To run script call -  
`./hack/import-cluster/start.sh`

First ensure that the authentication information for the cluster is filled into the `values.yaml`. 

Can call `./hack/import-cluster/uninstall.sh` to delete.

Script may not be perfect. Tested on mac only.


This PR likely shouldnt be merged (yet).