### PR TITLE
Track UID in status manager

### DIFF
--- a/controllers/backplaneconfig_controller.go
+++ b/controllers/backplaneconfig_controller.go
@@ -114,6 +114,16 @@ func (r *MultiClusterEngineReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, nil
 	}
 
+	// reset status manager if req is a new MCE
+	uid := string(backplaneConfig.UID)
+	if uid == "" {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, e.New("Resource missing UID")
+	}
+	if r.StatusManager.UID == "" || r.StatusManager.UID != string(backplaneConfig.UID) {
+		log.Info("Setting status manager to track new MCE", "UID", string(backplaneConfig.UID))
+		r.StatusManager.Reset(string(backplaneConfig.UID))
+	}
+
 	defer func() {
 		log.Info("Updating status")
 		backplaneConfig.Status = r.StatusManager.ReportStatus(*backplaneConfig)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -9,8 +9,16 @@ import (
 
 type StatusTracker struct {
 	Client     client.Client
+	UID        string
 	Components []StatusReporter
 	Conditions []bpv1alpha1.MultiClusterEngineCondition
+}
+
+// Flush out any cached data being tracked, and assigns the tracker to a UID
+func (sm *StatusTracker) Reset(uid string) {
+	sm.UID = uid
+	sm.Components = []StatusReporter{}
+	sm.Conditions = []bpv1alpha1.MultiClusterEngineCondition{}
 }
 
 // Adds a StatusReporter to the list of statuses to watch


### PR DESCRIPTION
The status manager is linked to the MultiClusterEngineReconciler and tracks
components added during reconciliation. To track status on an MCE basis the
manager should be reset on each new MCE reconciled, which can be traced via
UID.

Signed-off-by: Jakob Gray <20209054+JakobGray@users.noreply.github.com>